### PR TITLE
Tasks path change

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ bundle exec rspec spec/models
 - [Show](#tasks-show)
 - [Create](#tasks-create)
 - [Update](#tasks-update)
+- [Delete](#tasks-delete)
 
 ### Login
 - [Login](#login)
@@ -737,6 +738,22 @@ Successful Response:
   "due_date": "12/25"
 }
 ```
+
+Unsuccessful Response:
+A valid list and task ID must be provided or a 404 status code (page not found) will be returned.
+
+### Tasks Delete
+
+#### DELETE /api/v1/lists/:list_id/tasks/:task_id
+
+##### Headers:
+```
+Content-Type: application/json
+Accept: application/json
+```
+
+Successful Response:
+Returns 204 status with no body
 
 Unsuccessful Response:
 A valid list and task ID must be provided or a 404 status code (page not found) will be returned.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ bundle exec rspec spec/models
 ### Tasks
 - [Index](#tasks-index)
 - [Show](#tasks-show)
+- [Create](#tasks-create)
 
 ### Login
 - [Login](#login)
@@ -665,6 +666,46 @@ Successful Response:
 
 Unsuccessful Response:
 A valid list and task ID must be provided or a 404 status code (page not found) will be returned. Also the task given must be associated with the list given or a 404 will be returned.
+
+### Tasks Create
+
+#### post /api/v1/lists/:list_id/tasks
+
+##### Headers:
+```
+Content-Type: application/json
+Accept: application/json
+```
+
+##### Body:
+```
+{
+  name: 'Mow Back Yard',
+  description: 'make sure to weedeat',
+  list_id: 3,
+  due_date: '2019-12-25'
+}
+```
+*due date is optional*
+
+Successful Response:
+```json
+{
+  "id": 77,
+  "list_id": 3,
+  "name": "Mow Back Yard",
+  "description": "make sure to weedeat",
+  "completed": false,
+  "created_at": "2019-09-25T19:33:36.071Z",
+  "updated_at": "2019-09-25T19:33:36.071Z",
+  "due_date": "12/25"
+}
+```
+*Due date format is due to front end request*
+
+Unsuccessful Response:
+A valid list ID must be provided or a 404 status code (page not found) will be returned.
+
 
 ## Login
 Send a POST request to get user id from username and password

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ bundle exec rspec spec/models
 - [Delete](#lists-delete)
 ### Tasks
 - [Index](#tasks-index)
+- [Show](#tasks-show)
 
 ### Login
 - [Login](#login)
@@ -636,9 +637,34 @@ Successful Response:
 ]
 ```
 
-unsuccessful Response:
+Unsuccessful Response:
 A valid client or caretaker ID must be provided or a 404 status code (page not found) will be returned.
 
+### Tasks Show
+
+#### GET /api/v1/lists/:list_id/tasks/:task_id
+
+##### Headers:
+```
+Content-Type: application/json
+Accept: application/json
+```
+
+Successful Response:
+```json
+{
+    "id": 2,
+    "list_id": 1,
+    "name": "Green Onions",
+    "description": "Should be on sale",
+    "completed": false,
+    "created_at": "2019-09-21T18:56:50.738Z",
+    "updated_at": "2019-09-21T18:56:50.738Z"
+}
+```
+
+Unsuccessful Response:
+A valid list and task ID must be provided or a 404 status code (page not found) will be returned. Also the task given must be associated with the list given or a 404 will be returned.
 
 ## Login
 Send a POST request to get user id from username and password
@@ -736,10 +762,10 @@ Technical Debt: This project has two types of users, a client and a caretaker. W
 
 👤 **Noah Flint, Vince Carollo, Katie Lewis, Andreea Hanson**
 
-* [@n-flint](https://github.com/n-flint)
-* [@VinceCarollo](https://github.com/VinceCarollo)
-* [@Kalex19](https://github.com/Kalex19)
-* [@andreeahanson](https://github.com/andreeahanson)
+* [Vince Carollo](https://github.com/n-flint)
+* [Noah Flint](https://github.com/VinceCarollo)
+* [Katie Lewis](https://github.com/Kalex19)
+* [Andreea Hanson](https://github.com/andreeahanson)
 
 ## Frontend
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ bundle exec rspec spec/models
 - [Index](#tasks-index)
 - [Show](#tasks-show)
 - [Create](#tasks-create)
+- [Update](#tasks-update)
 
 ### Login
 - [Login](#login)
@@ -706,6 +707,39 @@ Successful Response:
 Unsuccessful Response:
 A valid list ID must be provided or a 404 status code (page not found) will be returned.
 
+### Tasks Update
+
+#### PATCH /api/v1/lists/:list_id/tasks/:task_id
+
+##### Headers:
+```
+Content-Type: application/json
+Accept: application/json
+```
+
+##### Body:
+```
+{
+  name: 'New Name'
+}
+```
+
+Successful Response:
+```json
+{
+  "id": 77,
+  "list_id": 3,
+  "name": "New Name",
+  "description": "make sure to weedeat",
+  "completed": false,
+  "created_at": "2019-09-25T19:33:36.071Z",
+  "updated_at": "2019-09-25T19:33:36.071Z",
+  "due_date": "12/25"
+}
+```
+
+Unsuccessful Response:
+A valid list and task ID must be provided or a 404 status code (page not found) will be returned.
 
 ## Login
 Send a POST request to get user id from username and password

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -32,6 +32,15 @@ class Api::V1::TasksController < ApplicationController
     render json: { message: 'Not Found' }, status: 404
   end
 
+  def destroy
+    list = List.find(params[:list_id])
+    task = list.tasks.find(params[:id])
+    task.destroy
+    render json: {}, status: 204
+  rescue ActiveRecord::RecordNotFound
+    render json: { message: 'Not Found' }, status: 404
+  end
+
   private
 
   def task_params

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -3,4 +3,12 @@ class Api::V1::TasksController < ApplicationController
     list = List.find(params[:list_id])
     render json: list.tasks.map{|task| TaskSerializer.new(task)}
   end
+
+  def show
+    list = List.find(params[:list_id])
+    task = list.tasks.find(params[:id])
+    render json: TaskSerializer.new(task)
+  rescue ActiveRecord::RecordNotFound
+    render json: { message: 'Not Found' }, status: 404
+  end
 end

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -23,6 +23,15 @@ class Api::V1::TasksController < ApplicationController
     end
   end
 
+  def update
+    list = List.find(params[:list_id])
+    task = list.tasks.find(params[:id])
+    task.update_attributes(task_params)
+    render json: TaskSerializer.new(task)
+  rescue ActiveRecord::RecordNotFound
+    render json: { message: 'Not Found' }, status: 404
+  end
+
   private
 
   def task_params

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::TasksController < ApplicationController
+  protect_from_forgery unless: -> { request.format.json? }
+
   def index
     list = List.find(params[:list_id])
     render json: list.tasks.map{|task| TaskSerializer.new(task)}
@@ -10,5 +12,20 @@ class Api::V1::TasksController < ApplicationController
     render json: TaskSerializer.new(task)
   rescue ActiveRecord::RecordNotFound
     render json: { message: 'Not Found' }, status: 404
+  end
+
+  def create
+    task = Task.new(task_params)
+    if task.save
+      render json: TaskSerializer.new(task)
+    else
+      render json: task.errors, status: 400
+    end
+  end
+
+  private
+
+  def task_params
+    params.permit(:name, :description, :list_id, :due_date)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,6 @@ Rails.application.routes.draw do
   root 'welcome#index'
   namespace :api do
     namespace :v1 do
-
       post '/speech', to: 'speech#index'
       post '/login', to: 'login#create'
 
@@ -11,9 +10,8 @@ Rails.application.routes.draw do
       resources :caretakers, only: [:create, :update, :destroy, :show, :index]
 
       resources :lists, only: [:index, :show, :create, :update, :destroy] do
-        resources :tasks, only: [:index, :show, :create, :update]
+        resources :tasks, only: [:index, :show, :create, :update, :destroy]
       end
-
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
       resources :caretakers, only: [:create, :update, :destroy, :show, :index]
 
       resources :lists, only: [:index, :show, :create, :update, :destroy] do
-        resources :tasks, only: [:index, :show, :create]
+        resources :tasks, only: [:index, :show, :create, :update]
       end
 
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
       resources :caretakers, only: [:create, :update, :destroy, :show, :index]
 
       resources :lists, only: [:index, :show, :create, :update, :destroy] do
-        resources :tasks, only: [:index]
+        resources :tasks, only: [:index, :show]
       end
 
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
       resources :caretakers, only: [:create, :update, :destroy, :show, :index]
 
       resources :lists, only: [:index, :show, :create, :update, :destroy] do
-        resources :tasks, only: [:index, :show]
+        resources :tasks, only: [:index, :show, :create]
       end
 
     end

--- a/db/migrate/20190904235439_create_tasks.rb
+++ b/db/migrate/20190904235439_create_tasks.rb
@@ -3,7 +3,7 @@ class CreateTasks < ActiveRecord::Migration[5.2]
     create_table :tasks do |t|
       t.string :name
       t.text :description
-      t.boolean :completed
+      t.boolean :completed, default: false
       t.references :list, foreign_key: true
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -60,7 +60,7 @@ ActiveRecord::Schema.define(version: 2019_09_11_021927) do
   create_table "tasks", force: :cascade do |t|
     t.string "name"
     t.text "description"
-    t.boolean "completed"
+    t.boolean "completed", default: false
     t.bigint "list_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/requests/api/v1/tasks/task_create_spec.rb
+++ b/spec/requests/api/v1/tasks/task_create_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+RSpec.describe 'Tasks Create API' do
+  it "can create a task" do
+    list = create(:list)
+
+    headers = {
+      content_type: "application/json",
+      accept: "application/json"
+    }
+
+    body = {
+      name: 'Mow Back Yard',
+      description: 'make sure to weedeat',
+      list_id: list.id,
+      due_date: '2019-12-28'
+    }
+
+    post "/api/v1/lists/#{list.id}/tasks", headers: headers, params: body
+
+    expect(response).to be_successful
+    expect(status).to eq(200)
+
+    task_data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(task_data[:name]).to eq(body[:name])
+    expect(task_data[:description]).to eq(body[:description])
+    expect(task_data[:completed]).to be false
+    expect(task_data[:list_id]).to eq(list.id)
+    expect(task_data).to have_key(:due_date)
+    expect(task_data).to have_key(:created_at)
+    expect(task_data).to have_key(:updated_at)
+
+    new_task = Task.last
+
+    expect(new_task.name).to eq(task_data[:name])
+  end
+
+  it "cant create a task without a list" do
+    headers = {
+      content_type: "application/json",
+      accept: "application/json"
+    }
+
+    body = {
+      name: 'Mow Back Yard',
+      description: 'make sure to weedeat',
+      due_date: '2019-12-28'
+    }
+
+    post "/api/v1/lists/invalid_id/tasks", headers: headers, params: body
+
+    expect(status).to eq(400)
+
+    error = JSON.parse(response.body, symbolize_names: true)
+
+    expect(error[:list]).to eq(['must exist'])
+  end
+
+  it "can create a task without a due date" do
+    list = create(:list)
+
+    headers = {
+      content_type: "application/json",
+      accept: "application/json"
+    }
+
+    body = {
+      name: 'Mow Back Yard',
+      description: 'make sure to weedeat',
+      list_id: list.id
+    }
+
+    post "/api/v1/lists/#{list.id}/tasks", headers: headers, params: body
+
+    expect(response).to be_successful
+    expect(status).to eq(200)
+
+    task_data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(task_data[:name]).to eq(body[:name])
+    expect(task_data[:description]).to eq(body[:description])
+    expect(task_data[:completed]).to be false
+    expect(task_data[:list_id]).to eq(list.id)
+    expect(task_data).to_not have_key(:due_date)
+    expect(task_data).to have_key(:created_at)
+    expect(task_data).to have_key(:updated_at)
+  end
+end

--- a/spec/requests/api/v1/tasks/task_delete_spec.rb
+++ b/spec/requests/api/v1/tasks/task_delete_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe 'Tasks Delete API' do
+  it "can delete a task" do
+    list = create(:list)
+    task = create(:task, list: list)
+
+    headers = {
+      content_type: "application/json",
+      accept: "application/json"
+    }
+
+    delete "/api/v1/lists/#{list.id}/tasks/#{task.id}"
+
+    expect(response).to be_successful
+    expect(status).to eq(204)
+
+    expect(Task.all.count).to eq(0)
+  end
+end

--- a/spec/requests/api/v1/tasks/task_read_spec.rb
+++ b/spec/requests/api/v1/tasks/task_read_spec.rb
@@ -29,4 +29,30 @@ RSpec.describe 'Tasks API' do
     expect(tasks.first[:completed]).to be false
     expect(tasks.first[:list_id]).to eq(list.id)
   end
+
+  it "gets one task" do
+    list = create(:list)
+    task = create(:task, list: list)
+
+    headers = {
+      content_type: "application/json",
+      accept: "application/json"
+    }
+
+    get "/api/v1/lists/#{list.id}/tasks/#{task.id}", headers: headers
+
+    expect(response).to be_successful
+    expect(status).to eq(200)
+
+    task_data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(task_data[:name]).to eq(task.name)
+    expect(task_data[:description]).to eq(task.description)
+    expect(task_data[:completed]).to eq(task.completed)
+    expect(task_data[:list_id]).to eq(task.list_id)
+
+    expect(task_data).to have_key(:due_date)
+    expect(task_data).to have_key(:created_at)
+    expect(task_data).to have_key(:updated_at)
+  end
 end

--- a/spec/requests/api/v1/tasks/task_read_spec.rb
+++ b/spec/requests/api/v1/tasks/task_read_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Tasks API' do
+RSpec.describe 'Tasks Read API' do
   it "gets all tasks" do
     list = create(:list)
     task1 = create(:task, list: list)

--- a/spec/requests/api/v1/tasks/task_update_spec.rb
+++ b/spec/requests/api/v1/tasks/task_update_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe 'Tasks Update API' do
+  it "can update a tasks name" do
+    list = create(:list)
+    task = create(:task, list: list)
+
+    body = {
+      name: 'New Task Name'
+    }
+
+    headers = {
+      content_type: "application/json",
+      accept: "application/json"
+    }
+
+    patch "/api/v1/lists/#{list.id}/tasks/#{task.id}", headers: headers, params: body
+
+    expect(response).to be_successful
+    expect(status).to eq(200)
+
+    task_data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(task_data[:name]).to eq('New Task Name')
+    expect(task_data).to have_key(:description)
+    expect(task_data).to have_key(:completed)
+    expect(task_data).to have_key(:list_id)
+    expect(task_data).to have_key(:due_date)
+    expect(task_data).to have_key(:created_at)
+    expect(task_data).to have_key(:updated_at)
+
+    task.reload
+
+    expect(task.name).to eq(body[:name])
+  end
+
+  it "can update a tasks due date" do
+    list = create(:list)
+    task = create(:task, list: list)
+
+    body = {
+      due_date: '2021-12-25'
+    }
+
+    headers = {
+      content_type: "application/json",
+      accept: "application/json"
+    }
+
+    patch "/api/v1/lists/#{list.id}/tasks/#{task.id}", headers: headers, params: body
+
+    expect(response).to be_successful
+    expect(status).to eq(200)
+
+    task.reload
+
+    expect(task.due_date).to eq(body[:due_date].to_datetime)
+  end
+end


### PR DESCRIPTION
### What does this PR do?

- Changes tasks attribute 'completed' to be false by default
- Consoldates endpoints:
  - /api/v1/caretakers/:caretaker_id/lists/:list_id/tasks
  - /api/v1/caretakers/:caretaker_id/lists/:list_id/tasks/:task_id
  or 
  - /api/v1/clients/:client_id/lists/:list_id/tasks/:task_id
  - /api/v1/clients/:client_id/lists/:list_id/tasks/:task_id
to: 
  - /api/v1/tasks