### PR TITLE
Update list creation docs in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,17 +458,13 @@ Content-Type: application/json
 Accept: application/json
 ```
 
-##### Body:
+##### params:
 ```
-{
-  client_id: 2
-}
+?client_id=2
 ```
 or
 ```
-{
-  caretaker_id: 2
-}
+?caretaker_id=2
 ```
 
 Successful Response:


### PR DESCRIPTION
### What does this PR do?

#### List Index endpoint:
Previously in order to get lists the readme directed users to add a body to get request with either the client or caretakers id. After doing some research it looks like that is against HTTP. 

##### Fix: 
Change readme to direct users to instead pass the client or caretaker id in params